### PR TITLE
Use DelayedArray:::set_dimnames()

### DIFF
--- a/R/writeHDF5Array.R
+++ b/R/writeHDF5Array.R
@@ -112,8 +112,7 @@ setAs("HDF5RealizationSink", "DelayedArray",
         ## HDF5ArraySeed does not propagate the dimnames at the moment. See
         ## FIXME above.
         ## TODO: Remove line below when FIXME above is addressed.
-        dimnames(ans) <- dimnames(from)
-        ans
+        DelayedArray:::set_dimnames(ans, dimnames(from))
     }
 )
 


### PR DESCRIPTION
Avoids unnecessarily degrading a HDF5Array with `NULL` dimnames to a DelayedArray in the coercion.