### PR TITLE
Add support for h5seurat object.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,8 +9,9 @@ Description: Implement the HDF5Array, H5SparseMatrix, H5ADMatrix, and
 	All these containers are DelayedArray extensions and thus support all
 	operations (delayed or block-processed) supported by DelayedArray
 	objects.
-biocViews: Infrastructure, DataRepresentation, DataImport, Sequencing, RNASeq,
-	Coverage, Annotation, GenomeAnnotation, SingleCell, ImmunoOncology
+biocViews: Infrastructure, DataRepresentation, DataImport, Sequencing,
+        RNASeq, Coverage, Annotation, GenomeAnnotation, SingleCell,
+        ImmunoOncology
 URL: https://bioconductor.org/packages/HDF5Array
 BugReports: https://github.com/Bioconductor/HDF5Array/issues
 Version: 1.26.0
@@ -18,37 +19,30 @@ License: Artistic-2.0
 Encoding: UTF-8
 Author: Hervé Pagès
 Maintainer: Hervé Pagès <hpages.on.github@gmail.com>
-Depends: R (>= 3.4), methods, DelayedArray (>= 0.15.16), rhdf5 (>= 2.31.6)
-Imports: utils, stats, tools, Matrix,
-	rhdf5filters, BiocGenerics (>= 0.31.5), S4Vectors, IRanges
+Depends: R (>= 3.4), methods, DelayedArray (>= 0.15.16), rhdf5 (>=
+        2.31.6)
+Imports: utils, stats, tools, Matrix, rhdf5filters, BiocGenerics (>=
+        0.31.5), S4Vectors, IRanges
 LinkingTo: S4Vectors (>= 0.27.13), Rhdf5lib
 SystemRequirements: GNU make
-Suggests: BiocParallel, GenomicRanges, SummarizedExperiment (>= 1.15.1),
-	h5vcData, ExperimentHub, TENxBrainData, zellkonverter, GenomicFeatures,
-	RUnit, SingleCellExperiment
-Collate: utils.R
-	H5File-class.R
-	h5ls.R
-	H5DSetDescriptor-class.R
-	h5utils.R
-	h5dimscales.R
-	uaselection.R
-	h5mread.R
-	h5mread_from_reshaped.R
-	h5writeDimnames.R
-	h5summarize.R
-	HDF5ArraySeed-class.R
-	HDF5Array-class.R
-	ReshapedHDF5ArraySeed-class.R
-	ReshapedHDF5Array-class.R
-	dump-management.R
-	writeHDF5Array.R
-	saveHDF5SummarizedExperiment.R
-	H5SparseMatrixSeed-class.R
-	H5SparseMatrix-class.R
-	H5ADMatrixSeed-class.R
-	H5ADMatrix-class.R
-	TENxMatrixSeed-class.R
-	TENxMatrix-class.R
-	writeTENxMatrix.R
-	zzz.R
+Suggests: BiocParallel, GenomicRanges, SummarizedExperiment (>=
+        1.15.1), h5vcData, ExperimentHub, TENxBrainData, zellkonverter,
+        GenomicFeatures, RUnit, SingleCellExperiment
+Collate: utils.R H5File-class.R h5ls.R H5DSetDescriptor-class.R
+        h5utils.R h5dimscales.R uaselection.R h5mread.R
+        h5mread_from_reshaped.R h5writeDimnames.R h5summarize.R
+        HDF5ArraySeed-class.R HDF5Array-class.R
+        ReshapedHDF5ArraySeed-class.R ReshapedHDF5Array-class.R
+        dump-management.R writeHDF5Array.R
+        saveHDF5SummarizedExperiment.R H5SparseMatrixSeed-class.R
+        H5SparseMatrix-class.R H5ADMatrixSeed-class.R
+        H5ADMatrix-class.R TENxMatrixSeed-class.R TENxMatrix-class.R
+        writeTENxMatrix.R H5SeuratMatrixSeed-class.R H5SeuratMatrix-class.R
+        zzz.R
+git_url: https://git.bioconductor.org/packages/HDF5Array
+git_branch: RELEASE_3_16
+git_last_commit: 38b7bd6
+git_last_commit_date: 2022-11-01
+Date/Publication: 2022-11-01
+NeedsCompilation: yes
+Packaged: 2022-11-01 21:44:25 UTC; biocbuild

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -37,7 +37,9 @@ exportClasses(
     H5ADMatrix,
     TENxMatrixSeed,
     TENxMatrix,
-    TENxRealizationSink
+    TENxRealizationSink,
+    H5SeuratMatrixSeed,
+    H5SeuratMatrix
 )
 
 
@@ -129,7 +131,9 @@ export(
     H5ADMatrix,
     TENxMatrixSeed,
     TENxMatrix,
-    TENxRealizationSink, writeTENxMatrix
+    TENxRealizationSink, writeTENxMatrix,
+    H5SeuratMatrixSeed,
+    H5SeuratMatrix
 )
 
 

--- a/R/H5SeuratMatrix-class.R
+++ b/R/H5SeuratMatrix-class.R
@@ -1,0 +1,67 @@
+### =========================================================================
+### H5SeuratMatrix objects
+### -------------------------------------------------------------------------
+###
+### Note that we could just wrap a H5SeuratMatrixSeed object in a DelayedMatrix
+### object to represent and manipulate a 10x Genomics dataset as a
+### DelayedMatrix object. So, strictly speaking, we don't really need the
+### H5SeuratMatrix class. However, we define this class mostly for cosmetic
+### reasons, that is, to hide the DelayedMatrix class from the user.
+### So the user will see and manipulate H5SeuratMatrix objects instead of
+### DelayedMatrix objects.
+###
+
+
+setClass("H5SeuratMatrix",
+    contains="DelayedMatrix",
+    representation(seed="H5SeuratMatrixSeed")
+)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Constructor
+###
+
+setMethod("DelayedArray", "H5SeuratMatrixSeed",
+    function(seed) new_DelayedArray(seed, Class="H5SeuratMatrix")
+)
+
+### Works directly on a TENxMatrixSeed object, in which case it must be
+### called with a single argument.
+H5SeuratMatrix <- function(filepath, group="matrix")
+{
+    if (is(filepath, "H5SeuratMatrixSeed")) {
+        if (!missing(group))
+            stop(wmsg("H5SeuratMatrix() must be called with a single argument ",
+                      "when passed a H5SeuratMatrixSeed object"))
+        seed <- filepath
+    } else {
+        seed <- H5SeuratMatrixSeed(filepath, group)
+    }
+    DelayedArray(seed)
+}
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Taking advantage of sparsity
+###
+
+setMethod("sparsity", "H5SeuratMatrix", function(x) sparsity(x@seed))
+
+setMethod("read_sparse_block", "H5SeuratMatrix",
+    function(x, viewport) read_sparse_block(x@seed, viewport)
+)
+
+setMethod("extractNonzeroDataByCol", "H5SeuratMatrix",
+    function(x, j) extractNonzeroDataByCol(x@seed, j)
+)
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Coercion to dgCMatrix
+###
+
+.from_H5SeuratMatrix_to_dgCMatrix <- function(from) as(from@seed, "dgCMatrix")
+setAs("H5SeuratMatrix", "dgCMatrix", .from_H5SeuratMatrix_to_dgCMatrix)
+setAs("H5SeuratMatrix", "sparseMatrix", .from_H5SeuratMatrix_to_dgCMatrix)
+

--- a/R/H5SeuratMatrixSeed-class.R
+++ b/R/H5SeuratMatrixSeed-class.R
@@ -1,0 +1,78 @@
+### =========================================================================
+### H5SeuratMatrixSeed objects
+### -------------------------------------------------------------------------
+
+setClass("H5SeuratMatrixSeed", contains="CSC_H5SparseMatrixSeed")
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Low-level helpers
+###
+
+.read_h5seurat_component <- function(filepath, name){
+    if (h5exists(filepath, name))
+        return(as.vector(h5mread(filepath, name)))
+    NULL
+}
+
+.load_tenx_rownames <- function(filepath, group)
+{
+    name <- .find_rownames_dataset(filepath, group)
+    # For h5seurat data
+    # Find /path/to/group/../
+    if (is.null(name))
+        name <- .find_rownames_dataset(filepath, gsub('/[^/]+$','',group))
+    if (is.null(name))
+        return(NULL)
+    read_h5sparse_component(filepath, group, name)
+}
+
+#.find_rownames_dataset <- function(filepath, group)
+#{
+#    name <- "genes"
+#    if (h5exists(filepath, paste(group, name, sep="/")))
+#        return(name)
+#    name <- "features/id"
+#    if (h5exists(filepath, paste(group, name, sep="/")))
+#        return(name)
+#    NULL
+#}
+
+### Return the rownames of the matrix.
+.load_tenx_rownames <- function(filepath, group)
+{
+    name <- .find_rownames_dataset(filepath, group)
+    if (is.null(name)){
+        # Support h5seurat
+        h5SeuratName <- file.path(gsub('/[^/]+$','',group), 'features')
+        return(.read_h5seurat_component(filepath, h5SeuratName))}
+    read_h5sparse_component(filepath, group, name)
+}
+
+### Return the colnames of the matrix.
+.load_tenx_barcodes <- function(filepath, group)
+{
+    if (!h5exists(filepath, paste0(group, "/barcodes"))){
+        return(.read_h5seurat_component(filepath, 'cell.names'))}
+    read_h5sparse_component(filepath, group, "barcodes")
+}
+
+
+### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+### Constructor
+###
+
+H5SeuratMatrixSeed <- function(filepath, group="matrix")
+{
+    seed0 <- H5SparseMatrixSeed(filepath, group)
+
+    ## dimnames
+    rownames <- .load_tenx_rownames(seed0@filepath, seed0@group)
+    stopifnot(is.null(rownames) || length(rownames) == seed0@dim[[1L]])
+    colnames <- .load_tenx_barcodes(seed0@filepath, seed0@group)
+    stopifnot(is.null(colnames) || length(colnames) == seed0@dim[[2L]])
+    dimnames <- list(rownames, colnames)
+
+    new2("H5SeuratMatrixSeed", seed0, dimnames=dimnames)
+}
+

--- a/R/H5SparseMatrixSeed-class.R
+++ b/R/H5SparseMatrixSeed-class.R
@@ -136,8 +136,12 @@ read_h5sparse_component <- function(filepath, group, name,
         ## 10x format
         return(read_h5sparse_component(filepath, group, "shape"))
     }
-    ## h5ad format
     h5attrs <- h5readAttributes(filepath, group)
+    ## h5seurat format
+    shape <- h5attrs$dims
+    if(!is.null(shape))
+        return(as.vector(shape))
+    ## h5ad format
     shape <- h5attrs$shape
     if (is.null(shape))
         shape <- h5attrs$h5sparse_shape
@@ -157,8 +161,12 @@ read_h5sparse_component <- function(filepath, group, name,
         ## 10x format
         return("csr")
     }
-    ## h5ad format
     h5attrs <- h5readAttributes(filepath, group)
+    ## h5seurat format
+    shape <- h5attrs$dims
+    if(!is.null(shape))
+        return("csr")
+    ## h5ad format
     h5sparse_format <- h5attrs[["encoding-type"]]
     if (is.null(h5sparse_format))
         h5sparse_format <- h5attrs[["h5sparse_format"]]


### PR DESCRIPTION
Add a new class H5SeuratMatrix to support for h5seurat HDF5 format sparse matrix ().
Because the shape/dims of h5seurat matrix is written on the attributes of data group rather than a "shape" DATASETS in data group, the matrix can not be load through "TENxMatrix" or "H5SparseMatrix".