### PR TITLE
Release 3 16

### DIFF
--- a/R/H5SparseMatrixSeed-class.R
+++ b/R/H5SparseMatrixSeed-class.R
@@ -136,8 +136,12 @@ read_h5sparse_component <- function(filepath, group, name,
         ## 10x format
         return(read_h5sparse_component(filepath, group, "shape"))
     }
-    ## h5ad format
     h5attrs <- h5readAttributes(filepath, group)
+    ## h5seurat format
+    shape <- h5attrs$dims
+    if(!is.null(shape))
+        return(as.vector(shape))
+    ## h5ad format
     shape <- h5attrs$shape
     if (is.null(shape))
         shape <- h5attrs$h5sparse_shape
@@ -157,8 +161,12 @@ read_h5sparse_component <- function(filepath, group, name,
         ## 10x format
         return("csr")
     }
-    ## h5ad format
     h5attrs <- h5readAttributes(filepath, group)
+    ## h5seurat format
+    shape <- h5attrs$dims
+    if(!is.null(shape))
+        return("csr")
+    ## h5ad format
     h5sparse_format <- h5attrs[["encoding-type"]]
     if (is.null(h5sparse_format))
         h5sparse_format <- h5attrs[["h5sparse_format"]]

--- a/man/TENxMatrix-class.Rd
+++ b/man/TENxMatrix-class.Rd
@@ -231,6 +231,20 @@ n_exprs3 <- lengths(nonzeros)
 ## Sanity checks:
 stopifnot(all.equal(lib_sizes, lib_sizes3))
 stopifnot(all.equal(n_exprs, n_exprs3))
+
+## ---------------------------------------------------------------------
+## SOME EXAMPLES OF H5SEURAT FORMAT
+## ---------------------------------------------------------------------
+fpath <- system.file('extdata','toy.h5seurat',package="HDF5Array")
+# Read count data of h5seurat dataset.
+group <- '/assays/RNA/counts'
+df.count <- HDF5Array::TENxMatrix(fpath, group)
+df.count[1:10,2:9]
+
+# Read normalized data of h5seurat dataset.
+group <- '/assays/RNA/data'
+df.data <- HDF5Array::TENxMatrix(fpath, group)
+df.data[1:10,2:9]
 }
 \keyword{classes}
 \keyword{methods}


### PR DESCRIPTION
Add support for h5seurat format to TENxMatrix object. In this version, only functions in `TENxMatrix-class` and `TENxMatrixSeed-class` has been changed. At the same time, I have added a toy data and written some example codes in the help document.

As a concern, the change in `.find_rownames_dataset` of `TENxMatrixSeed-class` is a little dangerous. I'm afraid that the 'features' prior than 'features/id' will cause a bug. However, if set 'feature/id' prior, it will cause an error: "Error in H5Lexists(fid, name) : HDF5. Links. Can't get value".
If the bug actually exist, it's maybe a solution to write a new function .read_h5seurat_component to read h5seurat data separately as in my last pull request.